### PR TITLE
Partial load capability for loading Raman mapping savefiles

### DIFF
--- a/iris/data/measurement_RamanMap.py
+++ b/iris/data/measurement_RamanMap.py
@@ -6,6 +6,8 @@ import platform
 
 import os
 import gc
+import shutil
+import tempfile
 import numpy as np
 import pandas as pd
 import bisect
@@ -1880,61 +1882,101 @@ class MeaRMap_Handler():
         
         return mappingUnit
             
-    def load_MappingMeasurementHub_database(self,hub:MeaRMap_Hub,loadpath:str,
-        flg_readraw:bool=True) -> MeaRMap_Hub:
+    def _resolve_meta_table(self, loadpath:str) -> tuple[sql.Connection, str]:
+        """
+        Opens a database connection and resolves the metadata table name, also setting
+        ``_table_prefix_load`` for subsequent load calls.
+
+        Args:
+            loadpath (str): path to the .db file
+
+        Returns:
+            tuple: (conn, db_tableName_meta)
+        """
+        assert os.path.exists(loadpath) and os.path.isfile(loadpath), \
+            '_resolve_meta_table: The input loadpath is not correct. Expected a valid file path.'
+        assert loadpath[-3:] == '.db', \
+            '_resolve_meta_table: The input loadpath is not correct. Expected a valid database file.'
+
+        conn:sql.Connection = sql.connect(loadpath)
+        conn.row_factory = sql.Row
+        cursor = conn.cursor()
+
+        acceptable_metaTableNames = [
+            self._dict_default_save_parameters['meta_table'],
+            self._table_prefix + self._dict_default_save_parameters['meta_table'],
+        ]
+        cursor.execute("SELECT name FROM sqlite_schema WHERE type='table';")
+        found_tableNames = [row[0] for row in cursor.fetchall()]
+        found_metaTableNames = [t for t in acceptable_metaTableNames if t in found_tableNames]
+        assert len(found_metaTableNames) == 1, (
+            '_resolve_meta_table: The database does not contain the mapping metadata '
+            'table OR more than 1 mapping metadata table found. Metadata table(s) found: {}'.format(found_metaTableNames))
+
+        db_tableName_meta:str = found_metaTableNames[0]
+        self._table_prefix_load = self._table_prefix if db_tableName_meta.startswith(self._table_prefix) else ''
+        return conn, db_tableName_meta
+
+    def get_MappingUnitNames_from_database(self, loadpath:str) -> dict[str, str]:
+        """
+        Reads only the metadata table from a .db save file and returns the available
+        mapping unit names without loading any measurement data.
+
+        Args:
+            loadpath (str): path to the .db file
+
+        Returns:
+            dict[str, str]: mapping of unit_id -> unit_name for every unit stored in the file
+        """
+        conn, db_tableName_meta = self._resolve_meta_table(loadpath)
+        cursor = conn.cursor()
+
+        dict_unit_id_to_name: dict[str, str] = {}
+        cursor.execute('SELECT * FROM {}'.format(db_tableName_meta))
+        for row in cursor.fetchall():
+            row: sql.Row
+            dict_unit_id_to_name[row[self._unit_id_key]] = row[self._unit_name_key]
+
+        conn.close()
+        return dict_unit_id_to_name
+
+    def load_MappingMeasurementHub_database(self, hub:MeaRMap_Hub, loadpath:str,
+        flg_readraw:bool=True, unit_names:list[str]|None=None) -> MeaRMap_Hub:
         """
         Loads the mapping measurement data from a database.
-        
+
         Args:
             hub (MappingMeasurement_Hub): mapping_measurement_hub object to be loaded into
             loadpath (str): path to load the data
-            flg_readraw (bool): flag to read the raw data (in addition to the averaged spectrum). Defaults to False.
-        
+            flg_readraw (bool): flag to read the raw data (in addition to the averaged spectrum). Defaults to True.
+            unit_names (list[str] | None): optional list of unit names to load. When provided,
+                only units whose name appears in this list are loaded. Unrecognised names are
+                silently ignored. When None (default), all units are loaded.
+
         Returns:
             mapping_measurement_new: mapping_measurement object
         """
-        assert os.path.exists(loadpath) and os.path.isfile(loadpath), 'load_mappingMeasurement_database: The input loadpath is not correct. Expected a valid file path.'
-        assert loadpath[-3:] == '.db', 'load_mappingMeasurement_database: The input loadpath is not correct. Expected a valid database file.'
-        
-        # Connect to the database
-        conn:sql.Connection = sql.connect(loadpath)
-        conn.row_factory = sql.Row  # To access the column names
+        conn, db_tableName_meta = self._resolve_meta_table(loadpath)
         cursor = conn.cursor()
-        
-        # Query the sqlite_schema table to get table names
-        # Check if the any of the metadata table names exist (check for with and without prefix)
-        acceptable_metaTableNames = []
-        acceptable_metaTableNames.append(self._dict_default_save_parameters['meta_table'])
-        acceptable_metaTableNames.append(self._table_prefix + self._dict_default_save_parameters['meta_table'])
-        
-        cursor.execute("SELECT name FROM sqlite_schema WHERE type='table';")
-        found_tableNames = [row[0] for row in cursor.fetchall()]
-        found_metaTableNames = [table_name for table_name in acceptable_metaTableNames if table_name in found_tableNames]
-        assert len(found_metaTableNames) == 1, ('load_mappingMeasurement_database: The database does not contain the mapping metadata '
-            'table OR more than 1 mapping metadata table found. Metadata table(s) found: {}'.format(found_metaTableNames))
-        db_tableName_meta:str = found_metaTableNames[0]
-        self._table_prefix_load = self._table_prefix if db_tableName_meta.startswith(self._table_prefix) else ''
-        
+
         # Get the metadata table and store it as a dictionary
-        dict_unit_id_to_name = {}
+        dict_unit_id_to_name: dict[str, str] = {}
         cursor.execute('SELECT * FROM {}'.format(db_tableName_meta))
-        rows = cursor.fetchall()
-        for row in rows:
+        for row in cursor.fetchall():
             row: sql.Row
             unit_id = row[self._unit_id_key]
             unit_name = row[self._unit_name_key]
-            dict_unit_id_to_name[unit_id] = unit_name
-        
+            if unit_names is None or unit_name in unit_names:
+                dict_unit_id_to_name[unit_id] = unit_name
+
         # Load the metadata and measurement data
-        # mapping_measurement = MappingMeasurement_Hub()
         mapping_measurement = hub
-        for unit_id in dict_unit_id_to_name.keys():
-            table_name = self._table_prefix + unit_id
-            unit_name = dict_unit_id_to_name[unit_id]
-            mappingUnit = MeaRMap_Unit(unit_name=unit_name,unit_id=unit_id)
-            mappingUnit = self._load_MappingMeasurementUnit_metadata_database(unit_id,conn,mappingUnit)
-            mappingUnit = self._load_MappingMeasurementUnit_measurement_database(unit_id,conn,loadpath,mappingUnit,flg_readraw)
+        for unit_id, unit_name in dict_unit_id_to_name.items():
+            mappingUnit = MeaRMap_Unit(unit_name=unit_name, unit_id=unit_id)
+            mappingUnit = self._load_MappingMeasurementUnit_metadata_database(unit_id, conn, mappingUnit)
+            mappingUnit = self._load_MappingMeasurementUnit_measurement_database(unit_id, conn, loadpath, mappingUnit, flg_readraw)
             mapping_measurement.append_mapping_unit(mappingUnit)
+        conn.close()
         return mapping_measurement
     
     def load_MappingMeasurement_pickle(self,hub:MeaRMap_Hub,loadpath:str) -> MeaRMap_Hub:
@@ -2394,9 +2436,51 @@ def test_handler():
     handler = MeaRMap_Handler()
     handler.test_database_save_load(hub)
     
+def test_load_partial():
+    handler = MeaRMap_Handler()
+    tmpdir = tempfile.mkdtemp()
+    savename = 'test_partial'
+    savepath = os.path.join(tmpdir, savename + '.db')
+
+    try:
+        print('>>>>> Creating dummy hub <<<<<')
+        hub = MeaRMap_Hub()
+        hub.test_generate_dummy()
+
+        print('>>>>> Saving to temporary file: {} <<<<<'.format(savepath))
+        thread = handler.save_MappingHub_database(hub, savedirpath=tmpdir, savename=savename)
+        thread.join()
+
+        print('\n>>>>> Scanning metadata (no measurement data loaded) <<<<<')
+        dict_id_to_name = handler.get_MappingUnitNames_from_database(savepath)
+        unit_names = list(dict_id_to_name.values())
+        for i, name in enumerate(unit_names):
+            print('  [{}] {}'.format(i, name))
+
+        print('\nEnter the start index (inclusive): ', end='', flush=True)
+        start = int(input())
+        print('Enter the end index (inclusive): ', end='', flush=True)
+        end = int(input())
+        selected_names = unit_names[start:end+1]
+        print('Loading units: {}'.format(selected_names))
+
+        loaded_hub = MeaRMap_Hub()
+        handler.load_MappingMeasurementHub_database(loaded_hub, savepath, unit_names=selected_names)
+
+        print('\n>>>>> Units loaded into hub <<<<<')
+        for uid in loaded_hub.get_list_MappingUnit_ids():
+            unit = loaded_hub.get_MappingUnit(uid)
+            print('  id={} | name={} | n_measurements={}'.format(
+                uid, unit.get_unit_name(), unit.get_numMeasurements()))
+
+    finally:
+        shutil.rmtree(tmpdir)
+        print('\n>>>>> Temporary files deleted <<<<<')
+
 if __name__ == '__main__':
     pass
-    test_handler()
+    test_load_partial()
+    # test_handler()
     
     # test_datasaveload_system()
     # test_datasaveload_system_txt()

--- a/iris/gui/dataHub_MeaRMap.py
+++ b/iris/gui/dataHub_MeaRMap.py
@@ -5,7 +5,7 @@ A class that stores the all the measurement data in the current experiment.
 - Allows the user to delete data from the table
 """
 import PySide6.QtWidgets as qw
-from PySide6.QtCore import Signal, Slot, QObject, QThread, QTimer, QCoreApplication
+from PySide6.QtCore import Signal, Slot, QObject, QThread, QTimer, QCoreApplication, Qt
 
 import os
 import psutil
@@ -31,10 +31,32 @@ from iris.data import SaveParamsEnum
 
 from iris.resources.dataHub_Raman_ui import Ui_DataHub_mapping
 from iris.resources.dataHubPlus_Raman_ui import Ui_DataHubPlus_mapping
+from iris.resources.dataHub_Raman_partialLoad_ui import Ui_dataHub_Raman_partialLoad
 
 DATAHUBPLUS_MAX_FREQ_HZ = 1.0 # Maximum update frequency for the DataHubPlus treeview in Hertz
 DATAHUB_OFFLOADCHECK_INTERVAL_SEC = 10.0  # Minimum interval between offload checks in seconds
 DATAHUB_OFFLOAD_MINMEMORY_GB = 1.0  # Minimum available memory in GB, under which offloading is triggered
+
+class Dlg_PartialLoad(qw.QDialog, Ui_dataHub_Raman_partialLoad):
+    """Dialog that lists all mapping units from a .db file as checkable items."""
+
+    def __init__(self, dict_id_to_name: dict[str, str], parent=None):
+        super().__init__(parent)
+        self.setupUi(self)
+        self.setWindowTitle("Select units to load")
+
+        self.tree_viewer.setHeaderLabel("Unit name")
+        self.tree_viewer.setSelectionMode(qw.QAbstractItemView.SelectionMode.ExtendedSelection)
+
+        for unit_id, unit_name in dict_id_to_name.items():
+            item = qw.QTreeWidgetItem(self.tree_viewer, [unit_name])
+            item.setData(0, Qt.ItemDataRole.UserRole, unit_id)
+
+        self.tree_viewer.selectAll()
+
+    def get_selected_unit_names(self) -> list[str]:
+        return [item.text(0) for item in self.tree_viewer.selectedItems()]
+
 
 class DataHub_Worker(QObject):
     
@@ -203,6 +225,18 @@ class DataHub_Worker(QObject):
             self.sig_saveload_done.emit(self.load_success)
         except Exception as e:
             self.sig_saveload_done.emit(self.load_error + str(e))
+
+    @Slot(str, list)
+    def load_database_partial(self, loadpath: str, unit_names: list[str]) -> None:
+        """
+        Load only the selected units from a database file.
+        """
+        try:
+            self._handler.load_MappingMeasurementHub_database(
+                self._mappinghub, loadpath=loadpath, flg_readraw=True, unit_names=unit_names)
+            self.sig_saveload_done.emit(self.load_success)
+        except Exception as e:
+            self.sig_saveload_done.emit(self.load_error + str(e))
     
     def set_MappingHub(self, mappingHub:MeaRMap_Hub):
         """
@@ -245,6 +279,7 @@ class Wdg_DataHub_Mapping(qw.QWidget):
     sig_autosave_db = Signal(str,str)   # Emitted to autosave the MappingMeasurement_Hub to the database
     sig_autoOffload_db = Signal(str,str) # Emitted to autosave and offload the MappingMeasurement_Hub to the database
     sig_load_db = Signal(str)           # Emitted to load the MappingMeasurement_Hub from the database
+    sig_load_db_partial = Signal(str, list)  # Emitted to partially load the MappingMeasurement_Hub from the database
     
     sig_autosave_db_delete = Signal(str, threading.Event)  # Emitted to delete the autosaved database file
 
@@ -284,7 +319,7 @@ class Wdg_DataHub_Mapping(qw.QWidget):
         # Widgets to show the stored data
         self._tree = wdg.tree_data
         self._tree.setColumnCount(3)
-        self._tree.setHeaderLabels(["Region of interest name", "Metadata", "Number of samplings"])
+        self._tree.setHeaderLabels(["Region of interest name", "Metadata", "Number of points"])
         
         # Set up the searchbar
         wdg.ent_searchbar.textChanged.connect(lambda: self.update_tree(keep_selection=False))
@@ -325,6 +360,7 @@ class Wdg_DataHub_Mapping(qw.QWidget):
         self.sig_autosave_db.connect(self._worker.autosave_database)
         self.sig_autosave_db_delete.connect(self._worker.autosave_database_delete)
         self.sig_load_db.connect(self._worker.load_database)
+        self.sig_load_db_partial.connect(self._worker.load_database_partial)
         
         # Delete unit connection setup
         self._sig_req_delte_unit.connect(self._worker.delete_unit)
@@ -682,19 +718,42 @@ class Wdg_DataHub_Mapping(qw.QWidget):
     @Slot()
     def _load_hub_database(self) -> None:
         """
-        Load a MappingMeasurement_Hub from a database file
+        Load a MappingMeasurement_Hub from a database file.
+        Opens a selection dialog so the user can choose which units to load.
         """
         self._btn_load_db.setEnabled(False)
         self._btn_load_db.setText("Loading...")
-        
+
         loadpath = qw.QFileDialog.getOpenFileName(
             None,
             "Load Mapping Hub database...",
             "",
             "Database files (*.db)"
         )[0]
-        
-        self.sig_load_db.emit(loadpath)
+
+        if not loadpath:
+            self._reset_reenable_saveload_buttons()
+            return
+
+        try:
+            dict_id_to_name = MeaRMap_Handler().get_MappingUnitNames_from_database(loadpath)
+        except Exception as e:
+            qw.QMessageBox.critical(self, "Load error", f"Could not read database metadata:\n{e}")
+            self._reset_reenable_saveload_buttons()
+            return
+
+        dlg = Dlg_PartialLoad(dict_id_to_name, parent=self)
+        if dlg.exec() != qw.QDialog.DialogCode.Accepted:
+            self._reset_reenable_saveload_buttons()
+            return
+
+        selected_names = dlg.get_selected_unit_names()
+        if not selected_names:
+            qw.QMessageBox.warning(self, "No units selected", "No units were selected to load.")
+            self._reset_reenable_saveload_buttons()
+            return
+
+        self.sig_load_db_partial.emit(loadpath, selected_names)
 
     @Slot()
     def _disable_saveload_buttons(self):

--- a/iris/gui/dataHub_MeaRMap.py
+++ b/iris/gui/dataHub_MeaRMap.py
@@ -319,7 +319,7 @@ class Wdg_DataHub_Mapping(qw.QWidget):
         # Widgets to show the stored data
         self._tree = wdg.tree_data
         self._tree.setColumnCount(3)
-        self._tree.setHeaderLabels(["Region of interest name", "Metadata", "Number of points"])
+        self._tree.setHeaderLabels(["Region of interest name", "Measurements", "Metadata"])
         
         # Set up the searchbar
         wdg.ent_searchbar.textChanged.connect(lambda: self.update_tree(keep_selection=False))
@@ -516,7 +516,7 @@ class Wdg_DataHub_Mapping(qw.QWidget):
         for unit_id in list_matched_ids:
             idx = list_unit_ids.index(unit_id)
             qw.QTreeWidgetItem(self._tree,
-                [list_unit_names[idx], str(list_metadata[idx]), str(list_num_measurements[idx])])
+                [list_unit_names[idx], str(list_num_measurements[idx]), str(list_metadata[idx])])
             
         # Set the selection back to the previous selection
         if keep_selection: self.set_selection_unitID(list_unitID)

--- a/iris/resources/dataHub_Raman_partialLoad.ui
+++ b/iris/resources/dataHub_Raman_partialLoad.ui
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>dataHub_Raman_partialLoad</class>
+ <widget class="QDialog" name="dataHub_Raman_partialLoad">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>679</width>
+    <height>505</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Select all the units to load:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QTreeWidget" name="tree_viewer">
+       <column>
+        <property name="text">
+         <string notr="true">1</string>
+        </property>
+       </column>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>dataHub_Raman_partialLoad</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>dataHub_Raman_partialLoad</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/iris/resources/dataHub_Raman_partialLoad_ui.py
+++ b/iris/resources/dataHub_Raman_partialLoad_ui.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+
+################################################################################
+## Form generated from reading UI file 'dataHub_Raman_partialLoad.ui'
+##
+## Created by: Qt User Interface Compiler version 6.10.1
+##
+## WARNING! All changes made in this file will be lost when recompiling UI file!
+################################################################################
+
+from PySide6.QtCore import (QCoreApplication, QDate, QDateTime, QLocale,
+    QMetaObject, QObject, QPoint, QRect,
+    QSize, QTime, QUrl, Qt)
+from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
+    QFont, QFontDatabase, QGradient, QIcon,
+    QImage, QKeySequence, QLinearGradient, QPainter,
+    QPalette, QPixmap, QRadialGradient, QTransform)
+from PySide6.QtWidgets import (QAbstractButton, QApplication, QDialog, QDialogButtonBox,
+    QHeaderView, QLabel, QSizePolicy, QTreeWidget,
+    QTreeWidgetItem, QVBoxLayout, QWidget)
+
+class Ui_dataHub_Raman_partialLoad(object):
+    def setupUi(self, dataHub_Raman_partialLoad):
+        if not dataHub_Raman_partialLoad.objectName():
+            dataHub_Raman_partialLoad.setObjectName(u"dataHub_Raman_partialLoad")
+        dataHub_Raman_partialLoad.resize(679, 505)
+        self.verticalLayout_2 = QVBoxLayout(dataHub_Raman_partialLoad)
+        self.verticalLayout_2.setObjectName(u"verticalLayout_2")
+        self.verticalLayout = QVBoxLayout()
+        self.verticalLayout.setObjectName(u"verticalLayout")
+        self.label = QLabel(dataHub_Raman_partialLoad)
+        self.label.setObjectName(u"label")
+
+        self.verticalLayout.addWidget(self.label)
+
+        self.tree_viewer = QTreeWidget(dataHub_Raman_partialLoad)
+        __qtreewidgetitem = QTreeWidgetItem()
+        __qtreewidgetitem.setText(0, u"1");
+        self.tree_viewer.setHeaderItem(__qtreewidgetitem)
+        self.tree_viewer.setObjectName(u"tree_viewer")
+
+        self.verticalLayout.addWidget(self.tree_viewer)
+
+
+        self.verticalLayout_2.addLayout(self.verticalLayout)
+
+        self.buttonBox = QDialogButtonBox(dataHub_Raman_partialLoad)
+        self.buttonBox.setObjectName(u"buttonBox")
+        self.buttonBox.setOrientation(Qt.Orientation.Horizontal)
+        self.buttonBox.setStandardButtons(QDialogButtonBox.StandardButton.Cancel|QDialogButtonBox.StandardButton.Ok)
+
+        self.verticalLayout_2.addWidget(self.buttonBox)
+
+
+        self.retranslateUi(dataHub_Raman_partialLoad)
+        self.buttonBox.accepted.connect(dataHub_Raman_partialLoad.accept)
+        self.buttonBox.rejected.connect(dataHub_Raman_partialLoad.reject)
+
+        QMetaObject.connectSlotsByName(dataHub_Raman_partialLoad)
+    # setupUi
+
+    def retranslateUi(self, dataHub_Raman_partialLoad):
+        dataHub_Raman_partialLoad.setWindowTitle(QCoreApplication.translate("dataHub_Raman_partialLoad", u"Dialog", None))
+        self.label.setText(QCoreApplication.translate("dataHub_Raman_partialLoad", u"Select all the units to load:", None))
+    # retranslateUi
+


### PR DESCRIPTION
## Summary:
- Added a functionality in the backend for partial savefile loading (Raman map)
- Added a GUI for it as well

## Copilot summary:
This pull request introduces a new feature for partial loading of mapping measurement units from a database file in the Raman mapping data handling workflow. Users can now select specific units to load from a `.db` file via a dialog in the GUI, improving performance and usability for large datasets. The changes include backend support for querying available units, modifications to the GUI to present a selection dialog, and updates to the loading logic to handle partial loads.

**Partial loading support for mapping measurement units:**

* `iris/data/measurement_RamanMap.py`:
  * Refactored the database loading logic to add `_resolve_meta_table` for metadata table resolution and `get_MappingUnitNames_from_database` to retrieve available unit names without loading all data. The main loading method now accepts an optional `unit_names` argument to load only selected units.
  * Added a test function `test_load_partial` to demonstrate and test the partial loading workflow.
  * Added necessary imports for temporary file handling.

**GUI enhancements for partial load:**

* `iris/gui/dataHub_MeaRMap.py`:
  * Added a new dialog class `Dlg_PartialLoad` for selecting units to load, using the new UI resource.
  * Updated the database loading workflow to present the selection dialog and emit a new signal for partial loading. [[1]](diffhunk://#diff-6873078222300cb733a8013ef0f4fd720c707de88f9ad488a5f8af1e511340acL685-R722) [[2]](diffhunk://#diff-6873078222300cb733a8013ef0f4fd720c707de88f9ad488a5f8af1e511340acL697-R756)
  * Added signal and slot connections for partial load, and updated the worker class to support partial loading. [[1]](diffhunk://#diff-6873078222300cb733a8013ef0f4fd720c707de88f9ad488a5f8af1e511340acR229-R240) [[2]](diffhunk://#diff-6873078222300cb733a8013ef0f4fd720c707de88f9ad488a5f8af1e511340acR282) [[3]](diffhunk://#diff-6873078222300cb733a8013ef0f4fd720c707de88f9ad488a5f8af1e511340acR363)
  * Minor tweaks to the tree view headers and update logic for clarity and consistency. [[1]](diffhunk://#diff-6873078222300cb733a8013ef0f4fd720c707de88f9ad488a5f8af1e511340acL287-R322) [[2]](diffhunk://#diff-6873078222300cb733a8013ef0f4fd720c707de88f9ad488a5f8af1e511340acL483-R519)
  * Added necessary Qt imports.

**New UI resources:**

* [`iris/resources/dataHub_Raman_partialLoad.ui`](diffhunk://#diff-4e01416247e0191a29967eb6675b90a8d672603cadaa4fff5c8b40ae38ed2422R1-R84): Added the UI definition for the partial load dialog.
* [`iris/resources/dataHub_Raman_partialLoad_ui.py`](diffhunk://#diff-ae519862e8e76911ff169538a91d636f09228b6832fe3404b1776dcc7ee185a1R1-R66): Generated Python code for the new dialog UI.

These changes collectively enable users to efficiently select and load only the desired regions of interest from large Raman mapping datasets, improving both memory usage and user experience.