### PR TITLE
added: multi-rename GUI and functionality

### DIFF
--- a/iris/gui/dataHub_MeaImg.py
+++ b/iris/gui/dataHub_MeaImg.py
@@ -23,6 +23,7 @@ from iris.data.calibration_objective import ImgMea_Cal, ImgMea_Cal_Hub
 from iris.resources.dataHub_image_ui import Ui_dataHub_image
 from iris.resources.objectives_ui import Ui_wdg_objectives
 from iris.resources.dialog_save_img_ui import Ui_dialog_save_imghub
+from iris.gui.dataHub_MeaRMap import Dlg_MultiRename
 
 class DataHub_Image_Design(Ui_dataHub_image,qw.QWidget):
     def __init__(self,parent):
@@ -604,29 +605,35 @@ class Wdg_DataHub_Image(qw.QWidget):
     @Slot()
     def rename_selected_ImageMeasurementUnit(self):
         """
-        Rename the selected ImageMeasurementUnit in the ImageMeasurement_Hub.
+        Rename the selected ImageMeasurementUnit(s) in the ImageMeasurement_Hub.
+        Single selection: simple text input. Multiple selection: multi-rename dialog.
         """
         selections = self._tree.selectedItems()
 
         if len(selections) == 0:
             qw.QMessageBox.warning(self, 'Error', 'No entry selected.'); return
-        if len(selections) > 1:
-            qw.QMessageBox.warning(self, 'Error', 'Please select only one unit to rename.'); return
-
-        unit_id = selections[0].text(0)
-        current_name = self.ImageHub.get_ImageMeasurementUnit(unit_id=unit_id).get_IdName()[1]
-
-        new_name, ok = qw.QInputDialog.getText(
-            self, 'Rename', 'Enter the new name:', text=current_name
-        )
-        if not ok: return
-
-        if not new_name:
-            qw.QMessageBox.warning(self, 'Error', 'Name cannot be empty.'); return
 
         try:
-            self.ImageHub.rename_ImageMeasurementUnit(unit_id, new_name)
-            self._flg_issaved = False
+            if len(selections) == 1:
+                unit_id = selections[0].text(0)
+                current_name = self.ImageHub.get_ImageMeasurementUnit(unit_id=unit_id).get_IdName()[1]
+                new_name, ok = qw.QInputDialog.getText(
+                    self, 'Rename', 'Enter the new name:', text=current_name)
+                if not ok: return
+                if not new_name:
+                    qw.QMessageBox.warning(self, 'Error', 'Name cannot be empty.'); return
+                self.ImageHub.rename_ImageMeasurementUnit(unit_id, new_name)
+                self._flg_issaved = False
+            else:
+                unit_ids = [item.text(0) for item in selections]
+                names = [item.text(1) for item in selections]
+                dlg = Dlg_MultiRename(names, parent=self)
+                if dlg.exec() != qw.QDialog.DialogCode.Accepted:
+                    return
+                new_names = dlg.get_new_names()
+                for unit_id, new_name in zip(unit_ids, new_names):
+                    self.ImageHub.rename_ImageMeasurementUnit(unit_id, new_name)
+                self._flg_issaved = False
         except AssertionError as e:
             qw.QMessageBox.warning(self, 'Error', str(e))
 

--- a/iris/gui/dataHub_MeaRMap.py
+++ b/iris/gui/dataHub_MeaRMap.py
@@ -32,6 +32,7 @@ from iris.data import SaveParamsEnum
 from iris.resources.dataHub_Raman_ui import Ui_DataHub_mapping
 from iris.resources.dataHubPlus_Raman_ui import Ui_DataHubPlus_mapping
 from iris.resources.dataHub_Raman_partialLoad_ui import Ui_dataHub_Raman_partialLoad
+from iris.resources.dialog_multiRename_ui import Ui_Dialog_MultiRename
 
 DATAHUBPLUS_MAX_FREQ_HZ = 1.0 # Maximum update frequency for the DataHubPlus treeview in Hertz
 DATAHUB_OFFLOADCHECK_INTERVAL_SEC = 10.0  # Minimum interval between offload checks in seconds
@@ -56,6 +57,39 @@ class Dlg_PartialLoad(qw.QDialog, Ui_dataHub_Raman_partialLoad):
 
     def get_selected_unit_names(self) -> list[str]:
         return [item.text(0) for item in self.tree_viewer.selectedItems()]
+
+
+class Dlg_MultiRename(qw.QDialog, Ui_Dialog_MultiRename):
+    """Dialog for renaming multiple mapping units at once (prefix, suffix, find/replace)."""
+
+    def __init__(self, names: list[str], parent=None):
+        super().__init__(parent)
+        self.setupUi(self)
+        self.setWindowTitle("Rename multiple units")
+        self._names = names
+
+        self.ent_prefix.textChanged.connect(self._update_preview)
+        self.ent_suffix.textChanged.connect(self._update_preview)
+        self.ent_replace_ori.textChanged.connect(self._update_preview)
+        self.ent_replace_with.textChanged.connect(self._update_preview)
+        self._update_preview()
+
+    def _apply_rename(self, name: str) -> str:
+        prefix = self.ent_prefix.text()
+        suffix = self.ent_suffix.text()
+        find = self.ent_replace_ori.text()
+        replace_with = self.ent_replace_with.text()
+        result = name.replace(find, replace_with) if find else name
+        return prefix + result + suffix
+
+    def _update_preview(self):
+        if self._names:
+            self.lbl_example.setText(self._apply_rename(self._names[0]))
+        else:
+            self.lbl_example.setText("N/A")
+
+    def get_new_names(self) -> list[str]:
+        return [self._apply_rename(name) for name in self._names]
 
 
 class DataHub_Worker(QObject):
@@ -603,27 +637,40 @@ class Wdg_DataHub_Mapping(qw.QWidget):
     @Slot()
     def rename_unit(self):
         """
-        Rename the selected MappingMeasurement_Unit in the MappingMeasurement_Hub
+        Rename the selected MappingMeasurement_Unit(s) in the MappingMeasurement_Hub.
+        Single selection: simple text input. Multiple selection: multi-rename dialog.
         """
         try:
             selections = self._tree.selectedItems()
-            
+
             if len(selections) == 0:
                 qw.QErrorMessage().showMessage("No unit selected")
                 return
-            elif len(selections) > 1:
-                qw.QErrorMessage().showMessage("Multiple units selected. Please select only one unit to rename")
-                return
-            
-            unit_name = selections[0].text(0)
-            unit = self._MappingHub.get_MappingUnit(unit_name=unit_name)
-            unit_id = unit.get_unit_id()
-            new_name, ok = qw.QInputDialog.getText(None, "Rename Mapping Unit", "Enter the new name for the selected Mapping Unit:",
-                                                    text=unit.get_unit_name())
-            if ok: self._MappingHub.rename_mapping_unit(unit_id, new_name)
-            self._flg_issaved_db = False
-        except Exception as e: qw.QMessageBox.warning(None, "Rename error", f"Error in renaming the Mapping Unit:\n{e}")
-        finally: self._sig_req_update_tree.emit()
+
+            if len(selections) == 1:
+                unit_name = selections[0].text(0)
+                unit = self._MappingHub.get_MappingUnit(unit_name=unit_name)
+                new_name, ok = qw.QInputDialog.getText(
+                    None, "Rename Mapping Unit",
+                    "Enter the new name for the selected Mapping Unit:",
+                    text=unit.get_unit_name())
+                if ok:
+                    self._MappingHub.rename_mapping_unit(unit.get_unit_id(), new_name)
+                    self._flg_issaved_db = False
+            else:
+                names = [item.text(0) for item in selections]
+                dlg = Dlg_MultiRename(names, parent=self)
+                if dlg.exec() != qw.QDialog.DialogCode.Accepted:
+                    return
+                new_names = dlg.get_new_names()
+                for unit_name, new_name in zip(names, new_names):
+                    unit = self._MappingHub.get_MappingUnit(unit_name=unit_name)
+                    self._MappingHub.rename_mapping_unit(unit.get_unit_id(), new_name)
+                self._flg_issaved_db = False
+        except Exception as e:
+            qw.QMessageBox.warning(None, "Rename error", f"Error in renaming the Mapping Unit:\n{e}")
+        finally:
+            self._sig_req_update_tree.emit()
     
     @Slot()
     def delete_unit(self):

--- a/iris/gui/submodules/mappingCoordinatesTreeview.py
+++ b/iris/gui/submodules/mappingCoordinatesTreeview.py
@@ -14,6 +14,7 @@ if __name__ == '__main__':
 from iris.data.measurement_coordinates import MeaCoor_mm, List_MeaCoor_Hub
 
 from iris.resources.dataHub_coor_ui import Ui_dataHub_coor
+from iris.gui.dataHub_MeaRMap import Dlg_MultiRename
 
 class DataHub_Coor_UiDesign(qw.QWidget, Ui_dataHub_coor):
     def __init__(self, parent):
@@ -279,27 +280,37 @@ class Wdg_Treeview_MappingCoordinates(qw.QWidget):
     
     def rename_MappingCoordinate(self):
         """
-        Renames the selected mapping coordinate in the list.
+        Renames the selected mapping coordinate(s) in the list.
+        Single selection: simple text input. Multiple selection: multi-rename dialog.
         """
         list_names = [item.text(1) for item in self._tree.selectedItems()]
-        
+
         if len(list_names) == 0:
             qw.QMessageBox.information(self, 'No selection', 'No mapping coordinates have been selected.')
-        elif len(list_names) > 1:
-            qw.QMessageBox.information(self, 'Multiple selection', 'Please select only one mapping coordinate to rename at a time.')
             return
-        
-        init_name = list_names[0]
-        while True:
-            try:
-                new_name,ok = qw.QInputDialog.getText(self, 'Rename mapping coordinate',
-                    f'Enter the new name for the mapping coordinate for\n"{init_name}":',
-                    text=init_name)
-                if not ok: return
-                self._mappingCoorHub.rename_mappingCoor(init_name, new_name)
-                break
-            except ValueError as e:
-                qw.QMessageBox.warning(self, 'Error',f"Invalid unit name: {e}")
+
+        if len(list_names) == 1:
+            init_name = list_names[0]
+            while True:
+                try:
+                    new_name, ok = qw.QInputDialog.getText(self, 'Rename mapping coordinate',
+                        f'Enter the new name for the mapping coordinate for\n"{init_name}":',
+                        text=init_name)
+                    if not ok: return
+                    self._mappingCoorHub.rename_mappingCoor(init_name, new_name)
+                    break
+                except ValueError as e:
+                    qw.QMessageBox.warning(self, 'Error', f"Invalid unit name: {e}")
+        else:
+            dlg = Dlg_MultiRename(list_names, parent=self)
+            if dlg.exec() != qw.QDialog.DialogCode.Accepted:
+                return
+            new_names = dlg.get_new_names()
+            for old_name, new_name in zip(list_names, new_names):
+                try:
+                    self._mappingCoorHub.rename_mappingCoor(old_name, new_name)
+                except ValueError as e:
+                    qw.QMessageBox.warning(self, 'Error', f"Invalid unit name: {e}")
     
     def _remove_selected_mapping_coordinate(self):
         """

--- a/iris/resources/dialog_multiRename.ui
+++ b/iris/resources/dialog_multiRename.ui
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog_MultiRename</class>
+ <widget class="QDialog" name="Dialog_MultiRename">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>627</width>
+    <height>389</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Add prefix:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="ent_prefix"/>
+     </item>
+     <item>
+      <widget class="Line" name="line_2">
+       <property name="orientation">
+        <enum>Qt::Orientation::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Add sufix:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="ent_suffix"/>
+     </item>
+     <item>
+      <widget class="Line" name="line">
+       <property name="orientation">
+        <enum>Qt::Orientation::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Replace text:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_5">
+       <property name="text">
+        <string>Replace:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="ent_replace_ori"/>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>With:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="ent_replace_with"/>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QLabel" name="label_7">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Example:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="lbl_example">
+         <property name="text">
+          <string>N/A</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>Dialog_MultiRename</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>Dialog_MultiRename</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/iris/resources/dialog_multiRename_ui.py
+++ b/iris/resources/dialog_multiRename_ui.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+
+################################################################################
+## Form generated from reading UI file 'dialog_multiRename.ui'
+##
+## Created by: Qt User Interface Compiler version 6.10.1
+##
+## WARNING! All changes made in this file will be lost when recompiling UI file!
+################################################################################
+
+from PySide6.QtCore import (QCoreApplication, QDate, QDateTime, QLocale,
+    QMetaObject, QObject, QPoint, QRect,
+    QSize, QTime, QUrl, Qt)
+from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
+    QFont, QFontDatabase, QGradient, QIcon,
+    QImage, QKeySequence, QLinearGradient, QPainter,
+    QPalette, QPixmap, QRadialGradient, QTransform)
+from PySide6.QtWidgets import (QAbstractButton, QApplication, QDialog, QDialogButtonBox,
+    QFrame, QHBoxLayout, QLabel, QLineEdit,
+    QSizePolicy, QVBoxLayout, QWidget)
+
+class Ui_Dialog_MultiRename(object):
+    def setupUi(self, Dialog_MultiRename):
+        if not Dialog_MultiRename.objectName():
+            Dialog_MultiRename.setObjectName(u"Dialog_MultiRename")
+        Dialog_MultiRename.resize(627, 389)
+        self.verticalLayout_2 = QVBoxLayout(Dialog_MultiRename)
+        self.verticalLayout_2.setObjectName(u"verticalLayout_2")
+        self.verticalLayout = QVBoxLayout()
+        self.verticalLayout.setObjectName(u"verticalLayout")
+        self.label_2 = QLabel(Dialog_MultiRename)
+        self.label_2.setObjectName(u"label_2")
+
+        self.verticalLayout.addWidget(self.label_2)
+
+        self.ent_prefix = QLineEdit(Dialog_MultiRename)
+        self.ent_prefix.setObjectName(u"ent_prefix")
+
+        self.verticalLayout.addWidget(self.ent_prefix)
+
+        self.line_2 = QFrame(Dialog_MultiRename)
+        self.line_2.setObjectName(u"line_2")
+        self.line_2.setFrameShape(QFrame.Shape.HLine)
+        self.line_2.setFrameShadow(QFrame.Shadow.Sunken)
+
+        self.verticalLayout.addWidget(self.line_2)
+
+        self.label_3 = QLabel(Dialog_MultiRename)
+        self.label_3.setObjectName(u"label_3")
+
+        self.verticalLayout.addWidget(self.label_3)
+
+        self.ent_suffix = QLineEdit(Dialog_MultiRename)
+        self.ent_suffix.setObjectName(u"ent_suffix")
+
+        self.verticalLayout.addWidget(self.ent_suffix)
+
+        self.line = QFrame(Dialog_MultiRename)
+        self.line.setObjectName(u"line")
+        self.line.setFrameShape(QFrame.Shape.HLine)
+        self.line.setFrameShadow(QFrame.Shadow.Sunken)
+
+        self.verticalLayout.addWidget(self.line)
+
+        self.label = QLabel(Dialog_MultiRename)
+        self.label.setObjectName(u"label")
+
+        self.verticalLayout.addWidget(self.label)
+
+        self.label_5 = QLabel(Dialog_MultiRename)
+        self.label_5.setObjectName(u"label_5")
+
+        self.verticalLayout.addWidget(self.label_5)
+
+        self.ent_replace_ori = QLineEdit(Dialog_MultiRename)
+        self.ent_replace_ori.setObjectName(u"ent_replace_ori")
+
+        self.verticalLayout.addWidget(self.ent_replace_ori)
+
+        self.label_4 = QLabel(Dialog_MultiRename)
+        self.label_4.setObjectName(u"label_4")
+
+        self.verticalLayout.addWidget(self.label_4)
+
+        self.ent_replace_with = QLineEdit(Dialog_MultiRename)
+        self.ent_replace_with.setObjectName(u"ent_replace_with")
+
+        self.verticalLayout.addWidget(self.ent_replace_with)
+
+        self.horizontalLayout = QHBoxLayout()
+        self.horizontalLayout.setObjectName(u"horizontalLayout")
+        self.label_7 = QLabel(Dialog_MultiRename)
+        self.label_7.setObjectName(u"label_7")
+        sizePolicy = QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Preferred)
+        sizePolicy.setHorizontalStretch(0)
+        sizePolicy.setVerticalStretch(0)
+        sizePolicy.setHeightForWidth(self.label_7.sizePolicy().hasHeightForWidth())
+        self.label_7.setSizePolicy(sizePolicy)
+
+        self.horizontalLayout.addWidget(self.label_7)
+
+        self.lbl_example = QLabel(Dialog_MultiRename)
+        self.lbl_example.setObjectName(u"lbl_example")
+
+        self.horizontalLayout.addWidget(self.lbl_example)
+
+
+        self.verticalLayout.addLayout(self.horizontalLayout)
+
+
+        self.verticalLayout_2.addLayout(self.verticalLayout)
+
+        self.buttonBox = QDialogButtonBox(Dialog_MultiRename)
+        self.buttonBox.setObjectName(u"buttonBox")
+        self.buttonBox.setOrientation(Qt.Orientation.Horizontal)
+        self.buttonBox.setStandardButtons(QDialogButtonBox.StandardButton.Cancel|QDialogButtonBox.StandardButton.Ok)
+
+        self.verticalLayout_2.addWidget(self.buttonBox)
+
+
+        self.retranslateUi(Dialog_MultiRename)
+        self.buttonBox.accepted.connect(Dialog_MultiRename.accept)
+        self.buttonBox.rejected.connect(Dialog_MultiRename.reject)
+
+        QMetaObject.connectSlotsByName(Dialog_MultiRename)
+    # setupUi
+
+    def retranslateUi(self, Dialog_MultiRename):
+        Dialog_MultiRename.setWindowTitle(QCoreApplication.translate("Dialog_MultiRename", u"Dialog", None))
+        self.label_2.setText(QCoreApplication.translate("Dialog_MultiRename", u"Add prefix:", None))
+        self.label_3.setText(QCoreApplication.translate("Dialog_MultiRename", u"Add sufix:", None))
+        self.label.setText(QCoreApplication.translate("Dialog_MultiRename", u"Replace text:", None))
+        self.label_5.setText(QCoreApplication.translate("Dialog_MultiRename", u"Replace:", None))
+        self.label_4.setText(QCoreApplication.translate("Dialog_MultiRename", u"With:", None))
+        self.label_7.setText(QCoreApplication.translate("Dialog_MultiRename", u"Example:", None))
+        self.lbl_example.setText(QCoreApplication.translate("Dialog_MultiRename", u"N/A", None))
+    # retranslateUi
+


### PR DESCRIPTION
## Quick summary:
- Added a new dialog GUI and functionality for multi-entry renames
- Implemented it in the Raman mapping datahub, image datahub, and the coorhub

## Copilot summary:
This pull request introduces a new dialog for batch renaming of units in the GUI, significantly improving the workflow for renaming multiple items at once. The new `Dlg_MultiRename` dialog allows users to add prefixes, suffixes, and perform find/replace operations on names in bulk, and is now integrated into the image measurement, mapping measurement, and mapping coordinate modules. Single selection continues to use a simple input dialog, while multiple selections now trigger the new batch rename dialog.

**Batch Rename Dialog Integration:**

* Added a new dialog `Dlg_MultiRename` (with UI in `dialog_multiRename.ui` and corresponding Python UI class in `dialog_multiRename_ui.py`) that enables batch renaming of units with prefix, suffix, and find/replace options. [[1]](diffhunk://#diff-0f0c04c9fcceae95ce95637f56f28fdb2af170241b495e455974672473f64f00R1-R153) [[2]](diffhunk://#diff-825f8e5766204a4dd9e675f9ede16c311ec505ad4f1a4920491bd542d601fa65R1-R138) [[3]](diffhunk://#diff-6873078222300cb733a8013ef0f4fd720c707de88f9ad488a5f8af1e511340acR62-R94)
* Integrated `Dlg_MultiRename` into the rename workflows for:
  - Image measurement units (`dataHub_MeaImg.py`): Multi-selection now opens the batch rename dialog. [[1]](diffhunk://#diff-6413e0e254d9d9d6de80903f58f5e557d652a8bceacb6cd1c3995198511618b2R26) [[2]](diffhunk://#diff-6413e0e254d9d9d6de80903f58f5e557d652a8bceacb6cd1c3995198511618b2L607-R634)
  - Mapping measurement units (`dataHub_MeaRMap.py`): Multi-selection now opens the batch rename dialog. [[1]](diffhunk://#diff-6873078222300cb733a8013ef0f4fd720c707de88f9ad488a5f8af1e511340acR35) [[2]](diffhunk://#diff-6873078222300cb733a8013ef0f4fd720c707de88f9ad488a5f8af1e511340acL606-R673)
  - Mapping coordinates (`mappingCoordinatesTreeview.py`): Multi-selection now opens the batch rename dialog. [[1]](diffhunk://#diff-6b9b5efaa006aa2450a14af4d9b72508ad9e86aaa60ac39584f6a4b9ae8bfe1cR17) [[2]](diffhunk://#diff-6b9b5efaa006aa2450a14af4d9b72508ad9e86aaa60ac39584f6a4b9ae8bfe1cL282-R292) [[3]](diffhunk://#diff-6b9b5efaa006aa2450a14af4d9b72508ad9e86aaa60ac39584f6a4b9ae8bfe1cR304-R313)

**User Experience Improvements:**

* Previous restriction of only allowing single selection for renaming has been removed; users can now rename multiple items in one operation, improving efficiency and consistency. [[1]](diffhunk://#diff-6413e0e254d9d9d6de80903f58f5e557d652a8bceacb6cd1c3995198511618b2L607-R634) [[2]](diffhunk://#diff-6873078222300cb733a8013ef0f4fd720c707de88f9ad488a5f8af1e511340acL606-R673) [[3]](diffhunk://#diff-6b9b5efaa006aa2450a14af4d9b72508ad9e86aaa60ac39584f6a4b9ae8bfe1cL282-R292)

No breaking changes are introduced; single-item renaming remains unchanged, while multi-item renaming is now much more powerful and user-friendly.